### PR TITLE
Generate AppImage for Linux

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,28 @@
+language: cpp
+compiler: gcc
+sudo: require
+dist: trusty
+
+before_install:
+    - sudo add-apt-repository ppa:beineri/opt-qt58-trusty -y
+    - sudo apt-get update -qq
+    
+install: 
+    - sudo apt-get -y install qt58base
+    - source /opt/qt58/bin/qt58-env.sh
+
+script:
+  - qmake PREFIX=/usr
+  - make -j4
+  - mkdir -p appdir/usr/bin ; mkdir -p appdir/usr/share/{applications,icons} ; cd appdir
+  - cp ../esptool-gui usr/bin
+  - cp ../tools-linux/tool-esptool/esptool usr/bin
+  - cp ../*.desktop .
+  - touch esptool-gui.png # FIXME
+  - cd .. 
+  - wget -c "https://github.com/probonopd/linuxdeployqt/releases/download/3/linuxdeployqt-3-x86_64.AppImage" 
+  - chmod a+x linuxdeployqt*.AppImage
+  - unset QTDIR; unset QT_PLUGIN_PATH ; unset LD_LIBRARY_PATH
+  - ./linuxdeployqt*.AppImage ./appdir/usr/bin/esptool-gui -bundle-non-qt-libs
+  - ./linuxdeployqt*.AppImage ./appdir/usr/bin/esptool-gui -appimage 
+  - curl --upload-file ./esptool-gui-*.AppImage https://transfer.sh/esptool-gui-git.$(git rev-parse --short HEAD)-x86_64.AppImage 

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ before_install:
     - sudo apt-get update -qq
     
 install: 
-    - sudo apt-get -y install qt58base
+    - sudo apt-get -y install qt58base qt58serialport
     - source /opt/qt58/bin/qt58-env.sh
 
 script:

--- a/esptool-gui.desktop
+++ b/esptool-gui.desktop
@@ -1,0 +1,6 @@
+[Desktop Entry]
+Type=Application
+Name=esptool-gui
+Exec=esptool-gui
+Icon=esptool-gui
+Categories=Development;


### PR DESCRIPTION
![screenshot from 2017-02-26 01-36-26](https://cloud.githubusercontent.com/assets/2480569/23336069/1a35e450-fbc4-11e6-95ac-64fc1e0feac6.png)

This patch, when merged, will build continuous builds for Linux and bundle them as an [AppImage](http://appimage.org/) on [Travis CI](https://travis-ci.org/) (need to enable Travis CI for the repository like [shown here](https://travis-ci.org/getting_started)).

Providing an AppImage would have, among others, these advantages:
- Works for most Linux distributions (including Ubuntu, Fedora, openSUSE, CentOS, elementaryOS, Linux Mint, and others)
- One app = one file = super simple for users: just download one AppImage file, [make it executable](http://discourse.appimage.org/t/how-to-make-an-appimage-executable/80), and run
- No unpacking or installation necessary
- No root needed
- No system libraries changed
- Just one format for all major distributions
- Works out of the box, no installation of runtimes needed
- Optional(!) desktop integration with `appimaged`
- Binary delta updates, e.g., for continuous builds (only download the binary diff) using AppImageUpdate
- Can GPG2-sign your AppImages (inside the file)

[Here is an overview](https://github.com/probonopd/AppImageKit/wiki/AppImages) of projects that are already distributing upstream-provided, official AppImages.